### PR TITLE
Fix counting of docstrings as LOC and comment. Update manual metrics for parsing.py

### DIFF
--- a/parsing/parsing.py
+++ b/parsing/parsing.py
@@ -1,7 +1,5 @@
 """
-This module handles parsing by line.
-
-Used for Line of Code Counts and Comment counts
+This module handles Python module parsing.
 """
 
 from typing import Dict, List
@@ -161,7 +159,11 @@ class Parsing:
 
     def parse(self) -> Dict[str, int]:
         self._metrics = self._AstParsing.parse()
+        # LineParser counts docstring comments as lines.
+        # Remove them so they are not double counted.
+        remove_lines = self._metrics["NOC"]
         add_dicts(self._LineParsing.parse(), self._metrics)
+        self._metrics["NOL"] -= remove_lines
         return self._metrics
 
 

--- a/test_data/parsingtestmetrics.csv
+++ b/test_data/parsingtestmetrics.csv
@@ -1,16 +1,16 @@
 ﻿Metric,Value
-Number of Lines,27
-Number of Comments,9
-Number of Classes,1
+Number of Lines,123
+Number of Comments,24
+Number of Classes,3
 Number of Inherited Methods,0
-Number of Hierarchies,0
+Number of Hierarchies,1
 Number of Abstract Classes,0
-Number of Leaf Classes,0
+Number of Leaf Classes,2
 Average Number of Parameters per method,1
-Number of Attributes,5
+Number of Attributes,10
 Average Width of Inheritance,0
 Number of Classes of nesting level 0,1
-Number of Classes of nesting level 1,0
+Number of Classes of nesting level 1,2
 Number of Classes of nesting level 2,0
 Number of Classes of nesting level 3,0
 Number of Classes of nesting level 4,0
@@ -20,10 +20,10 @@ Number of Classes of nesting level 7,0
 Number of Classes of nesting level 8,0
 Number of Classes of nesting level 9,0
 Number of Classes of nesting level 10,0
-Number of Local Methods,2
+Number of Local Methods,6
 Number of Nested Classes,0
 Ratio of comment Line to the executable statements,0
-Total Number of Methods,2
+Total Number of Methods,6
 Number of overridden methods,0
 Average Number of Inherited Methods per Class,0
 Average Number of Local methods per Class,2


### PR DESCRIPTION
manual metrics were generated for an older version of parsing.py